### PR TITLE
SocketTimeoutException ErrorMsg case fix

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
@@ -180,7 +180,7 @@ public class TestHiveMetaStoreTimeout {
       try(HiveMetaStoreClient c = new HiveMetaStoreClient(newConf)) {
         Assert.fail("should throw connection timeout exception.");
       } catch (MetaException e) {
-        Assert.assertTrue("unexpected Exception", e.getMessage().contains("connect timed out"));
+        Assert.assertTrue("unexpected Exception", e.getMessage().toLowerCase().contains("connect timed out"));
       }
       return null;
     });


### PR DESCRIPTION
In jdk13, the Java Socket API was reimplemented. 
The default Socket API implementation is changed from PlainSocketImp to NioSocketImpl .
NioSocketImpl  leverages the java.nio infrastructure for better concurrency and i/o control.
This new default implementation returns the error message "Connect timed out" as compared to earlier "connect timed out".
This issue is easily addressed by searching for the "connect timed out" string after lower casing the complete error message.